### PR TITLE
feat: remote dns

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -64,8 +64,9 @@ func serverHandle(_ *cobra.Command, _ []string) {
 		log.WithField("err", err).Error("Run nodes failed")
 		return
 	}
+	dns := os.Getenv("XRAY_DNS_PATH")
 	if watch {
-		err = c.Watch(config, func() {
+		err = c.Watch(config, dns, func() {
 			nodes.Close()
 			err = vc.Close()
 			if err != nil {

--- a/core/xray/app/dispatcher/default.go
+++ b/core/xray/app/dispatcher/default.go
@@ -5,12 +5,13 @@ package dispatcher
 import (
 	"context"
 	"fmt"
-	"github.com/Yuzuki616/V2bX/common/rate"
-	"github.com/Yuzuki616/V2bX/limiter"
-	routingSession "github.com/xtls/xray-core/features/routing/session"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Yuzuki616/V2bX/common/rate"
+	"github.com/Yuzuki616/V2bX/limiter"
+	routingSession "github.com/xtls/xray-core/features/routing/session"
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
@@ -480,7 +481,7 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 				l.ConnLimiter.DelConnCount(sessionInbound.User.Email, sessionInbound.Source.Address.IP().String())
 			}()
 		}
-		if l.CheckDomainRule(destination.String()) {
+		if l.CheckDomainRule(destination.Address.String()) {
 			newError(fmt.Sprintf("User %s access %s reject by rule", sessionInbound.User.Email, destination.String())).AtError().WriteToLog()
 			common.Close(link.Writer)
 			common.Interrupt(link.Reader)

--- a/core/xray/xray.go
+++ b/core/xray/xray.go
@@ -1,9 +1,6 @@
 package xray
 
 import (
-	"os"
-	"sync"
-
 	"github.com/Yuzuki616/V2bX/conf"
 	vCore "github.com/Yuzuki616/V2bX/core"
 	"github.com/Yuzuki616/V2bX/core/xray/app/dispatcher"
@@ -19,6 +16,8 @@ import (
 	"github.com/xtls/xray-core/features/routing"
 	statsFeature "github.com/xtls/xray-core/features/stats"
 	coreConf "github.com/xtls/xray-core/infra/conf"
+	"os"
+	"sync"
 )
 
 func init() {
@@ -61,6 +60,7 @@ func getCore(c *conf.XrayConfig) *core.Instance {
 	coreLogConfig.ErrorLog = c.LogConfig.ErrorPath
 	// DNS config
 	coreDnsConfig := &coreConf.DNSConfig{}
+	os.Setenv("XRAY_DNS_PATH", "")
 	if c.DnsConfigPath != "" {
 		if f, err := os.Open(c.DnsConfigPath); err != nil {
 			log.WithField("err", err).Panic("Failed to read DNS config file")
@@ -69,6 +69,7 @@ func getCore(c *conf.XrayConfig) *core.Instance {
 				log.WithField("err", err).Panic("Failed to unmarshal DNS config")
 			}
 		}
+		os.Setenv("XRAY_DNS_PATH", c.DnsConfigPath)
 	}
 	dnsConfig, err := coreDnsConfig.Build()
 	if err != nil {


### PR DESCRIPTION
support v2board panel to deliver dns configuration

It must have the keyword main to activate the dns configuration, and it does not support the same vps multi-node ids to be delivered separately.

```
main
{ 
  "servers": [
    "1.1.1.1",
    "localhost",
    {
      "address": "https://dns-hk.bigmeok.me:4434/dns-query",
      "domains": [
        "# > DAZN",
        "domain:dazn-api.com",
        "domain:dazn.com",
        "domain:dazndn.com",
        "domain:indazn.com",
        "domain:d151l6v8er5bdm.cloudfront.net",
        "domain:d1sgwhnao7452x.cloudfront.net",
        "domain:dcalivedazn.akamaized.net",
        "domain:dcblivedazn.akamaized.net"
      ]
    }
  ],
  "tag": "dns_inbound"
}
```